### PR TITLE
Add vim-gfm-syntax support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An extension for [telescope.nvim](https://github.com/nvim-telescope/telescope.nv
 
 ## Supported File Type
 
-- Markdown, including `vimwiki` and `vim-pandoc-syntax`.
+- Markdown, including `vimwiki`, `vim-pandoc-syntax`, and `vim-gfm-syntax`.
 - AsciiDoc (experimental)
 - LaTeX (experimental)
 - OrgMode (experimental)

--- a/lua/telescope/_extensions/heading.lua
+++ b/lua/telescope/_extensions/heading.lua
@@ -15,6 +15,7 @@ local function filetype()
     local ft_maps = {
         ['vimwiki'] = 'markdown',
         ['markdown.pandoc'] = 'markdown',
+        ['markdown.gfm'] = 'markdown',
         ['tex'] = 'latex',
     }
     local ft = vim.bo.filetype


### PR DESCRIPTION
[vim-gfm-sytax](https://github.com/rhysd/vim-gfm-syntax) is a vim plugin that supports github flavoured markdown.
Its filetype is named `markdown.gfm`, currently not supported by telescope-heading.
I'd like to see this supported.