### PR TITLE
Added pandoc filetype to ft_map

### DIFF
--- a/lua/telescope/_extensions/heading.lua
+++ b/lua/telescope/_extensions/heading.lua
@@ -14,6 +14,7 @@ local conf = require('telescope.config').values
 local function filetype()
     local ft_maps = {
         ['vimwiki'] = 'markdown',
+        ['pandoc'] = 'markdown',
         ['markdown.pandoc'] = 'markdown',
         ['markdown.gfm'] = 'markdown',
         ['tex'] = 'latex',


### PR DESCRIPTION
Added `pandoc` filetype to filetype list since it doesn't seem covered by `markdown.pandoc` case.
