### PR TITLE
feat: user can change the picker layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,24 @@ telescope.load_extension('heading')
 
 If `nvim-treesitter` was not correctly loaded, it would have fallen back to normal parsing. You may check `nvim-treesitter` configurations and whether your language is `TSInstall`ed.
 
+### Setup telescope picker options
+
+```lua
+local telescope = require('telescope')
+telescope.setup({
+    -- ...
+    extensions = {
+        heading = {
+          picker_opts = {
+              layout_config = { width = 0.8, preview_width = 0.5 },
+              layout_strategy = 'horizontal',
+          },
+        },
+        -- ...
+    },
+})
+```
+
 ## Usage
 
 ```viml

--- a/lua/telescope/_extensions/heading.lua
+++ b/lua/telescope/_extensions/heading.lua
@@ -79,7 +79,7 @@ local function get_headings()
 end
 
 local function pick_headings(opts)
-    opts = opts or {}
+    opts = vim.tbl_deep_extend('keep', opts or {}, heading_config.picker_opts)
 
     local headings = get_headings()
     if headings == nil then

--- a/lua/telescope/_extensions/heading/config.lua
+++ b/lua/telescope/_extensions/heading/config.lua
@@ -3,6 +3,7 @@ local telescope_heading = {
 }
 
 telescope_heading.setup = function(opts)
+    telescope_heading.picker_opts = opts.picker_opts or {}
     telescope_heading.treesitter = vim.F.if_nil(opts.treesitter, false)
 end
 


### PR DESCRIPTION
It overrides the default options of picker which defined in `telescope.setup {defaults = {...}}`.

preview:

<img width="1352" alt="CleanShot 2023-03-18 at 02 56 14@2x" src="https://user-images.githubusercontent.com/1998490/225993967-1cf74c80-69bb-4f8d-8f8a-79a9f7542a43.png">
