### PR TITLE
fix: Use vim.treesitter.query.parse() to avoid deprecation warning

### DIFF
--- a/lua/telescope/_extensions/heading/format/beancount.lua
+++ b/lua/telescope/_extensions/heading/format/beancount.lua
@@ -33,7 +33,8 @@ function Beancount.ts_get_headings(filepath, bufnr)
     local query = [[
     (section) (headline) (item) @heading
     ]]
-    local parsed_query = ts.parse_query('beancount', query)
+    local parse_query = ts.query.parse or ts.parse_query
+    local parsed_query = parse_query('beancount', query)
     local parser = ts.get_parser(bufnr, 'beancount')
     local root = parser:parse()[1]:root()
     local start_row, _, end_row, _ = root:range()

--- a/lua/telescope/_extensions/heading/format/help.lua
+++ b/lua/telescope/_extensions/heading/format/help.lua
@@ -48,7 +48,8 @@ function Help.ts_get_headings(filepath, bufnr)
     local query = [[
       (h1) @text.title
     ]]
-    local parsed_query = ts.parse_query('help', query)
+    local parse_query = ts.query.parse or ts.parse_query
+    local parsed_query = parse_query('help', query)
     local parser = ts.get_parser(bufnr, 'help')
     local root = parser:parse()[1]:root()
     local start_row, _, end_row, _ = root:range()

--- a/lua/telescope/_extensions/heading/format/markdown.lua
+++ b/lua/telescope/_extensions/heading/format/markdown.lua
@@ -47,7 +47,8 @@ function Markdown.ts_get_headings(filepath, bufnr)
     local query = [[
     (atx_heading) @heading
     ]]
-    local parsed_query = ts.parse_query('markdown', query)
+    local parse_query = ts.query.parse or ts.parse_query
+    local parsed_query = parse_query('markdown', query)
     local parser = ts.get_parser(bufnr, 'markdown')
     local root = parser:parse()[1]:root()
     local start_row, _, end_row, _ = root:range()

--- a/lua/telescope/_extensions/heading/format/norg.lua
+++ b/lua/telescope/_extensions/heading/format/norg.lua
@@ -45,7 +45,8 @@ function Neorg.ts_get_headings(filepath, bufnr)
 
     @heading
     ]]
-    local parsed_query = ts.parse_query('norg', query)
+    local parse_query = ts.query.parse or ts.parse_query
+    local parsed_query = parse_query('norg', query)
     local parser = ts.get_parser(bufnr, 'norg')
     local root = parser:parse()[1]:root()
     local start_row, _, end_row, _ = root:range()

--- a/lua/telescope/_extensions/heading/format/rst.lua
+++ b/lua/telescope/_extensions/heading/format/rst.lua
@@ -91,7 +91,8 @@ function ReStructuredText.ts_get_headings(filepath, bufnr)
     local query = [[
     (section) (title) @section_title
     ]]
-    local parsed_query = ts.parse_query('rst', query)
+    local parse_query = ts.query.parse or ts.parse_query
+    local parsed_query = parse_query('rst', query)
     local parser = ts.get_parser(bufnr, 'rst')
     local root = parser:parse()[1]:root()
     local start_row, _, end_row, _ = root:range()


### PR DESCRIPTION
fix: https://github.com/neovim/neovim/pull/22761