### PR TITLE
fix: asciidoc support

### DIFF
--- a/lua/telescope/_extensions/heading.lua
+++ b/lua/telescope/_extensions/heading.lua
@@ -20,6 +20,7 @@ local function filetype()
         ['markdown.gfm'] = 'markdown',
         ['tex'] = 'latex',
         ['help'] = 'vimdoc',
+        ['asciidoctor'] = 'asciidoc',
     }
     local ft = vim.bo.filetype
     if ft_maps[ft] ~= nil then


### PR DESCRIPTION
Plugin didn't recognize asciidoctor filetype, I've added it to `ft_maps`.