### PR TITLE
feat: display section number of LaTeX section headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ telescope.setup({
 })
 ```
 
+### File-type specific picker option
+
+- LaTeX
+  - `use_section_number`: display section number with section title
+
 ## Usage
 
 ```viml

--- a/lua/telescope/_extensions/heading.lua
+++ b/lua/telescope/_extensions/heading.lua
@@ -45,7 +45,7 @@ local function support_treesitter(ft)
     return false
 end
 
-local function get_headings()
+local function get_headings(opts)
     local ft = filetype()
     local mod_path =
         string.format('telescope._extensions.heading.format.%s', ft)
@@ -77,13 +77,13 @@ local function get_headings()
         end
     end
 
-    return mod.get_headings(filepath, index, total)
+    return mod.get_headings(filepath, index, total, opts)
 end
 
 local function pick_headings(opts)
     opts = vim.tbl_deep_extend('keep', opts or {}, heading_config.picker_opts)
 
-    local headings = get_headings()
+    local headings = get_headings(opts)
     if headings == nil then
         return
     end
@@ -96,7 +96,7 @@ local function pick_headings(opts)
                 entry_maker = function(entry)
                     return {
                         value = entry.line,
-                        display = entry.heading,
+                        display = entry.display or entry.heading,
                         ordinal = entry.heading,
                         filename = entry.path,
                         lnum = entry.line,

--- a/lua/telescope/_extensions/heading/format/latex.lua
+++ b/lua/telescope/_extensions/heading/format/latex.lua
@@ -61,7 +61,7 @@ function ArticleHeadingMaker:make_display_name(heading_name, section_title)
     if section_title == nil then
         return section_title
     else
-        return section_num .. ". " .. section_title
+        return section_num .. " " .. section_title
     end
 end
 

--- a/lua/telescope/_extensions/heading/format/latex.lua
+++ b/lua/telescope/_extensions/heading/format/latex.lua
@@ -40,13 +40,13 @@ function ArticleHeadingMaker:update_counter(heading_name)
     if heading_name == "section" then
         self.heading_counts["subsection"] = 0
         self.heading_counts["subsubsection"] = 0
-    elseif heading_name == "section" then
+    elseif heading_name == "subsection" then
         self.heading_counts["subsubsection"] = 0
     end
     self.heading_counts[heading_name] = self.heading_counts[heading_name] + 1
 end
 
-function ArticleHeadingMaker:make_display_name(heading_name, section_name)
+function ArticleHeadingMaker:make_display_name(heading_name, section_title)
     local section_num = nil
     if heading_name == "section" then
         section_num = self.heading_counts["section"]
@@ -58,10 +58,10 @@ function ArticleHeadingMaker:make_display_name(heading_name, section_name)
                       .. self.heading_counts["subsection"] .. "."
                       .. self.heading_counts["subsubsection"]
     end
-    if section_name == nil then
-        return section_name
+    if section_title == nil then
+        return section_title
     else
-        return section_num .. ". " .. section_name
+        return section_num .. ". " .. section_title
     end
 end
 
@@ -101,11 +101,12 @@ function Latex.get_headings(filepath, start, total, opts)
 
         if not skip then
             local pattern = "\\" .. headingname .. "{([^}]*)}"
-            local section_name = string.match(vim.trim(line), pattern)
+            local section_title = string.match(vim.trim(line), pattern)
             local display_name = nil
             if opts.use_section_number then
                 article_heading_maker:update_counter(headingname)
-                display_name = article_heading_maker:make_display_name(headingname, section_name)
+                display_name = article_heading_maker:make_display_name(headingname, section_title
+ )
             end
             table.insert(headings, {
                 heading = vim.trim(line),


### PR DESCRIPTION
## Overview

Thank you for awesome plugin!
I love using it!

This PR improves display of LaTeX sections.
Here is screenshots which describs the change of results window display.

- Original

<img width="1582" alt="latex-display-original" src="https://github.com/crispgm/telescope-heading.nvim/assets/52688583/973e1988-8fa1-43a1-882c-f3cdc11fa0f8">

- Display with section number (which this PR implements)

<img width="1582" alt="latex-display-with-section-number" src="https://github.com/crispgm/telescope-heading.nvim/assets/52688583/905cacac-3fb9-44f3-bddf-450922eec744">

## Some background

Usually LaTeX files are finally rendered into pdf file, and section numbers (which are automatically caluculated) are displayed in resulting pdf files.

Here is an example.

- LaTeX source (`test-heading.tex`)

```
\documentclass{article}

\begin{document}

\section{Section}
\subsection{Subsection}
\subsubsection{Subsubsection}
\section{Section2}
\subsection{Subsection}
\subsubsection{Subsubsection}
\subsubsection{Subsubsection2}
\subsection{Subsection2}
\subsubsection{Subsubsection}
\subsubsection{Subsubsection2}

\end{document}
```

- Rendered pdf (produced by `pdflatex test-heading.tex`)

<img width="1205" alt="rendererd-preview" src="https://github.com/crispgm/telescope-heading.nvim/assets/52688583/5231daec-2cd4-4fb2-b14f-84cbdbed4d54">

## What this PR implements

I think it is nice to see section numbers also in picker results window, rather than displaying raw LaTeX command (like `\subsection{...}`.
So I implemented the entry display with section numbers.

I added picker (opt-in) option `use_section_number` for the main picker, and if it is set `true` use display with section numbers.
I also added description of this option in `README`.

## Caveats

This display style assumes that the document have `*article` documentstyle.
`*article` type documentstyle is most common, but for other document styles picker display and rendered display can differ.